### PR TITLE
add bare domain (qdn) example.com to full domain (fqdn) 

### DIFF
--- a/15-deployment/blue_yellow_app_deployment/deploy/group_vars/all
+++ b/15-deployment/blue_yellow_app_deployment/deploy/group_vars/all
@@ -4,6 +4,7 @@ ssh_dir: "/home/matt/"
 ssh_key_name: "do_deploy"
 
 fqdn: "www.pythondeploymentexample.com"
+qdn: "pythondeploymentexample.com"
 web_serve_dir: "/var/www/html"
 ssl_cert_email: "matthew.makai@gmail.com"
 

--- a/15-deployment/blue_yellow_app_deployment/deploy/roles/common/tasks/letsencrypt.yml
+++ b/15-deployment/blue_yellow_app_deployment/deploy/roles/common/tasks/letsencrypt.yml
@@ -27,7 +27,7 @@
 
 
 - name: create certificate with letsencrypt command
-  shell: "letsencrypt certonly --standalone -d {{ fqdn }} -w {{ web_serve_dir }} -m {{ ssl_cert_email }} --agree-tos --renew-by-default"
+  shell: "letsencrypt certonly --standalone -d {{ fqdn }} -d {{ qdn}} -w {{ web_serve_dir }} -m {{ ssl_cert_email }} --agree-tos --renew-by-default"
   become: true
   when: not certs.stat.exists
 

--- a/15-deployment/blue_yellow_app_deployment/deploy/roles/common/templates/nginx_ssl.conf.j2
+++ b/15-deployment/blue_yellow_app_deployment/deploy/roles/common/templates/nginx_ssl.conf.j2
@@ -4,12 +4,12 @@ upstream app_server_wsgiapp {
 
 server {
   listen 80;
-  server_name {{ fqdn }};
+  server_name {{ fqdn }} {{ qdn }};
   rewrite ^(.*) https://$server_name$1 permanent;
 }
 
 server {
-  server_name           {{ fqdn }};
+  server_name           {{ fqdn }} {{ qdn }};
   listen                443 ssl;
   ssl_certificate /etc/letsencrypt/live/{{ fqdn }}/fullchain.pem;
   ssl_certificate_key /etc/letsencrypt/live/{{ fqdn }}/privkey.pem;


### PR DESCRIPTION
www.example.com for ssl in lets encrypt step in Ansible playbook.  

I've implemented these changes for my implementation in internodal.xyz. While not required, the bare domain is not supported without these changes. 